### PR TITLE
Save prediction results as a dataframe

### DIFF
--- a/beta_rec/core/eval_engine.py
+++ b/beta_rec/core/eval_engine.py
@@ -149,6 +149,7 @@ def test_eval_worker(testEngine, eval_data_df, prediction):
 
     Prediction and evaluation on the testing set.
     """
+    config = testEngine.config["system"]
     result_para = {
         "run_time": [testEngine.config["run_time"]],
     }
@@ -166,9 +167,19 @@ def test_eval_worker(testEngine, eval_data_df, prediction):
     test_result_dic.update(result_para)
     lock_test_eval.acquire()  # need to be test
     result_df = pd.DataFrame(test_result_dic)
-    save_to_csv(result_df, testEngine.config["system"]["result_file"])
+    save_to_csv(result_df, config["result_file"])
     lock_test_eval.release()
     testEngine.n_worker -= 1
+    save_mode = config["save_mode"]
+    if save_mode == "per_user":
+        rating_pre_df = eval_data_df.drop(columns=["col_timestamp"])
+        rating_pre_df["col_prediction"] = prediction
+        save_to_csv(
+            rating_pre_df,
+            config["root_dir"] + "/" + config["result_dir"] + config["model_run_id"],
+        )
+    else:
+        pass
     return test_result_dic
 
 

--- a/configs/lcfn_default.json
+++ b/configs/lcfn_default.json
@@ -14,7 +14,8 @@
         "k": [5,10,20],
         "valid_metric": "ndcg",
         "valid_k": 10,
-        "result_file": "lcfn_result.csv"
+        "result_file": "lcfn_result.csv",
+        "save_mode": "average"
     },
     "dataset": {
         "dataset": "ml_100k",

--- a/configs/lightgcn_default.json
+++ b/configs/lightgcn_default.json
@@ -14,7 +14,8 @@
         "k": [5, 10, 20],
         "valid_metric": "ndcg",
         "valid_k": 10,
-        "result_file": "lightgcn_result.csv"
+        "result_file": "lightgcn_result.csv",
+        "save_mode": "average"
     },
     "dataset": {
         "dataset": "ml_100k",

--- a/configs/mf_default.json
+++ b/configs/mf_default.json
@@ -14,7 +14,8 @@
         "k": [5,10,20],
         "valid_metric": "ndcg",
         "valid_k": 10,
-        "result_file": "mf_result.csv"
+        "result_file": "mf_result.csv",
+        "save_mode": "average"
     },
     "dataset": {
         "dataset": "ml_100k",

--- a/configs/narm_default.json
+++ b/configs/narm_default.json
@@ -14,7 +14,8 @@
         "k": [5, 10],
         "valid_metric": "ndcg",
         "valid_k": 10,
-        "result_file": "result.csv"
+        "result_file": "result.csv",
+        "save_mode": "average"
     },
     "dataset": {
         "dataset": "ml_100k",

--- a/configs/ncf_default.json
+++ b/configs/ncf_default.json
@@ -14,7 +14,8 @@
         "k": [5,10,20],
         "valid_metric": "ndcg",
         "valid_k": 10,
-        "result_file": "ncf_result.csv"
+        "result_file": "ncf_result.csv",
+        "save_mode": "average"
     },
     "dataset": {
         "dataset": "ml_100k",

--- a/configs/ngcf_default.json
+++ b/configs/ngcf_default.json
@@ -14,7 +14,8 @@
         "k": [5, 10, 20],
         "valid_metric": "ndcg",
         "valid_k": 10,
-        "result_file": "ngcf_result.csv"
+        "result_file": "ngcf_result.csv",
+        "save_mode": "average"
     },
     "dataset": {
         "dataset": "ml_100k",

--- a/configs/triple2vec_default.json
+++ b/configs/triple2vec_default.json
@@ -14,7 +14,8 @@
         "k": [5,10,20],
         "valid_metric": "ndcg",
         "valid_k": 10,
-        "result_file": "triple2vec_result.csv"
+        "result_file": "triple2vec_result.csv",
+        "save_mode": "average"
     },
     "dataset": {
         "dataset": "dunnhumby",

--- a/configs/vbcar_default.json
+++ b/configs/vbcar_default.json
@@ -14,7 +14,8 @@
         "k": [5,10,20],
         "valid_metric": "ndcg",
         "valid_k": 10,
-        "result_file": "vbcar_result.csv"
+        "result_file": "vbcar_result.csv",
+        "save_mode": "average"
     },
     "dataset": {
         "dataset": "tafeng",


### PR DESCRIPTION
#356 Save the predicted results as a dataframe together with the user, item id and the ground truth. The dataframe is saved under the /result file, named with the model_run_id. The structure of the dataframe is 
col_user,col_item,col_rating,col_prediction