### PR TITLE
Update lightgcn.py

### DIFF
--- a/beta_rec/models/lightgcn.py
+++ b/beta_rec/models/lightgcn.py
@@ -67,7 +67,7 @@ class LightGCN(torch.nn.Module):
         if self.training:
 
             norm_adj = self.dropout(x=norm_adj, keep_prob=self.config["keep_pro"])
-            
+
         for layer in range(self.n_layers):
 
             all_emb = torch.sparse.mm(norm_adj, all_emb)

--- a/beta_rec/models/lightgcn.py
+++ b/beta_rec/models/lightgcn.py
@@ -21,6 +21,7 @@ class LightGCN(torch.nn.Module):
 
         self.user_embedding = nn.Embedding(self.n_users, self.emb_dim)
         self.item_embedding = nn.Embedding(self.n_items, self.emb_dim)
+        self.f = nn.Sigmoid()
         self.init_emb()
 
     def dropout(self, x, keep_prob):
@@ -63,7 +64,10 @@ class LightGCN(torch.nn.Module):
         #     norm_adj = self.dropout(x=norm_adj, keep_prob=self.config["keep_pro"])
         # else:
         #     norm_adj = norm_adj
-        norm_adj = self.dropout(x=norm_adj, keep_prob=self.config["keep_pro"])
+        if self.training:
+
+            norm_adj = self.dropout(x=norm_adj, keep_prob=self.config["keep_pro"])
+            
         for layer in range(self.n_layers):
 
             all_emb = torch.sparse.mm(norm_adj, all_emb)
@@ -92,7 +96,7 @@ class LightGCN(torch.nn.Module):
             ua_embeddings, ia_embeddings = self.forward(self.norm_adj)
             u_g_embeddings = ua_embeddings[users_t]
             i_g_embeddings = ia_embeddings[items_t]
-            scores = torch.mul(u_g_embeddings, i_g_embeddings).sum(dim=1)
+            scores = self.f(torch.mul(u_g_embeddings, i_g_embeddings).sum(dim=1))
         return scores
 
 


### PR DESCRIPTION
1. Fix the dropout issue: The dropout function was called in all forward passes. Now it's only called for each training forward pass.
2. Add the nn.Sigmoid() for the prediction layer.