### PR TITLE
Fixed a bug in EvalEngine

### DIFF
--- a/beta_rec/core/eval_engine.py
+++ b/beta_rec/core/eval_engine.py
@@ -242,7 +242,7 @@ class EvalEngine(object):
         if batch_eval:
             n_batch = len(data_df) // self.batch_size + 1
             predictions = np.array([])
-            stop_batch = False # If we need to set a smaller number of batches
+            stop_batch = False
             
             for idx in range(n_batch):
                 if not stop_batch:

--- a/beta_rec/core/eval_engine.py
+++ b/beta_rec/core/eval_engine.py
@@ -243,7 +243,6 @@ class EvalEngine(object):
             n_batch = len(data_df) // self.batch_size + 1
             predictions = np.array([])
             stop_batch = False
-            
             for idx in range(n_batch):
                 if not stop_batch:
                     start_idx = idx * self.batch_size


### PR DESCRIPTION
Fixed a bug in EvalEngine where it failed when a batch only contains a single (user, item) pair by adding that single pair to the second to last batch.

Related to Issue #431 